### PR TITLE
project admin query fix

### DIFF
--- a/archeobot/config/manager/kustomization.yaml
+++ b/archeobot/config/manager/kustomization.yaml
@@ -5,5 +5,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: image-registry.apps.emerald.devops.gov.bc.ca/devops-archeobot/archeobot
+  newName: image-registry.apps.klab.devops.gov.bc.ca/devops-archeobot/archeobot
   newTag: latest

--- a/archeobot/roles/artifactory_project/tasks/create-project.yaml
+++ b/archeobot/roles/artifactory_project/tasks/create-project.yaml
@@ -21,9 +21,10 @@
 
 - name: Filter rolebindings for admins and then pull out names only.
   set_fact:
-    admin_users: "{{ rolebindings | to_json | from_json | json_query(admin_query) | flatten | json_query(user_query) }}"
+    admin_users: "{{ rolebindings | to_json | from_json | json_query(admin_query) | json_query(type_query) | flatten | json_query(user_query) }}"
   vars:
-    admin_query: "resources[?starts_with(metadata.name,'admin')].subjects[*]"
+    admin_query: "resources[?roleRef.name=='admin']"
+    type_query: "[?roleRef.kind=='ClusterRole'].subjects[*]"
     user_query: "[?kind=='User'].name"
 
 - name: Add admin users

--- a/archeobot/roles/artifactory_serviceacct/tasks/main.yaml
+++ b/archeobot/roles/artifactory_serviceacct/tasks/main.yaml
@@ -90,7 +90,7 @@
 
 - name: Make pull secret json
   set_fact:
-    pull_json: '{"auths":{"artifacts.docker.gov.bc.ca":{"username":"{{ service_account_name }}","password":"{{ generated_password }}","email":"{{ pull_email }}","auth":"{{ pull_auth }}"}}}'
+    pull_json: '{"auths":{"artifacts.developer.gov.bc.ca":{"username":"{{ service_account_name }}","password":"{{ generated_password }}","email":"{{ pull_email }}","auth":"{{ pull_auth }}"}}}'
   when: (created_sa.changed)
 
 - name: Cast pull secret json


### PR DESCRIPTION
Archeobot used to collect the list of admin users in a namespace based on the name of the rolebinding. This often caused it to miss admin users (and could theoretically have been used to grant admin access inaccurately). Now it actually checks the role granted by each rolebinding, which is a much more appropriate way to collect this information.

Also there was a typo in the automatically generated pull secret for service accounts, which is now fixed.