### PR TITLE
update dns entries to point at gold

### DIFF
--- a/archeobot/config/deploy/emerald/base_dns.yaml
+++ b/archeobot/config/deploy/emerald/base_dns.yaml
@@ -12,11 +12,11 @@ spec:
             - name: ANSIBLE_GATHERING
               value: explicit
             - name: ARTIFACTORY_BASE_DNS
-              value: developer.gov.bc.ca
+              value: apps.gold.devops.gov.bc.ca
             - name: ARTIFACTORY_URL
-              value: https://artifacts.developer.gov.bc.ca
+              value: https://artifacts.apps.gold.devops.gov.bc.ca
             - name: CLUSTER_NAME
-              value: gold
+              value: emerald
             - name: WATCH_NAMESPACE
             - name: POD_NAME
               valueFrom:

--- a/archeobot/config/deploy/gold/base_dns.yaml
+++ b/archeobot/config/deploy/gold/base_dns.yaml
@@ -12,9 +12,9 @@ spec:
             - name: ANSIBLE_GATHERING
               value: explicit
             - name: ARTIFACTORY_BASE_DNS
-              value: developer.gov.bc.ca
+              value: apps.gold.devops.gov.bc.ca
             - name: ARTIFACTORY_URL
-              value: https://artifacts.developer.gov.bc.ca
+              value: https://artifacts.apps.gold.devops.gov.bc.ca
             - name: CLUSTER_NAME
               value: gold
             - name: WATCH_NAMESPACE

--- a/archeobot/config/deploy/silver/base_dns.yaml
+++ b/archeobot/config/deploy/silver/base_dns.yaml
@@ -12,9 +12,9 @@ spec:
             - name: ANSIBLE_GATHERING
               value: explicit
             - name: ARTIFACTORY_BASE_DNS
-              value: developer.gov.bc.ca
+              value: apps.gold.devops.gov.bc.ca
             - name: ARTIFACTORY_URL
-              value: https://artifacts.developer.gov.bc.ca
+              value: https://artifacts.apps.gold.devops.gov.bc.ca
             - name: CLUSTER_NAME
               value: silver
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
This is an update to reflect the new practice of pointing at the gold-specific URL instead of at the balancer, since archeobot should never point at Gold-DR, even in the event of a failover.