### PR TITLE
if notification fails, the rest of the process still continues

### DIFF
--- a/archeobot/Makefile
+++ b/archeobot/Makefile
@@ -71,11 +71,17 @@ undeploy: kustomize
 docker-build:
 	docker login ${REGISTRY} -u $(shell oc whoami) -p $(shell oc whoami -t)
 	docker build --platform=linux/amd64 -t ${REGISTRY}/${NAMESPACE}/${IMG} .
+podman-build:
+	podman login ${REGISTRY} -u $(shell oc whoami) -p $(shell oc whoami -t)
+	podman build --platform=linux/amd64 -t ${REGISTRY}/${NAMESPACE}/${IMG} .
 
 # Push the docker image
 docker-push:
 	docker login ${REGISTRY} -u $(shell oc whoami) -p $(shell oc whoami -t)
 	docker push ${REGISTRY}/${NAMESPACE}/${IMG}
+podman-push:
+	podman login ${REGISTRY} -u $(shell oc whoami) -p $(shell oc whoami -t)
+	podman push ${REGISTRY}/${NAMESPACE}/${IMG}
 
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH := $(shell uname -m | sed 's/x86_64/amd64/')

--- a/archeobot/roles/artifactory_project/tasks/nothing-to-approve.yaml
+++ b/archeobot/roles/artifactory_project/tasks/nothing-to-approve.yaml
@@ -10,10 +10,14 @@
     headers:
       Content-type: "application/json"
     body: "{{ lookup('template', 'notification.json.j2') }}"
-    status_code: 200,201
+    status_code: 200,201,404
   register: notification_sent
 
-- name: Change the status to 'pending'
+- set_fact:
+    new_approval_status: "pending-contactplatformservices"
+  when: notification_sent.status == 404
+
+- name: Change the status to 'pending' or 'pending-contactplatformservices'
   kubernetes.core.k8s:
     state: present
     template: 'artprojapp.yaml.j2'

--- a/archeobot/roles/artifactory_project/tasks/pending-contactplatfomservices.yaml
+++ b/archeobot/roles/artifactory_project/tasks/pending-contactplatfomservices.yaml
@@ -1,0 +1,5 @@
+---
+
+- name: The request is still pending, do nothing.
+  debug:
+    msg: "Pending change waiting on approval. Platform Services notification has not been sent!!"


### PR DESCRIPTION
Now a 404 is a valid response from n8n because otherwise the notification failure blocks the entire process so even if we find out we can't approve it until the notification succeeds. So now a 404 just creates a slightly different version of the pending status. 